### PR TITLE
RaisedButton width change

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -68,7 +68,7 @@ class _HomePageState extends State<HomePage> {
               ),
               Container( // Button
                 margin: EdgeInsets.only(top: 20),
-                width: 100,
+                width: 110,
                 height: 40,
                 child: RaisedButton(
                   child: Text(


### PR DESCRIPTION

![Screenshot_2020-04-22-21-14-14-736_com example infodog](https://user-images.githubusercontent.com/59681238/80009083-35e89180-84e6-11ea-9f0a-5a84c5c566ab.jpg)
On my device the width of 100 is making the 'e' of 'change' to go in next line.So fixed it.